### PR TITLE
Fixed bug causing infinit loop due to missed continue parameter in GE…

### DIFF
--- a/page/page.go
+++ b/page/page.go
@@ -173,6 +173,7 @@ func (page *WikipediaPage) ContinuedQuery(args map[string]string) ([]interface{}
 		utils.UpdateMap(new_args, last)
 
 		res, err := utils.WikiRequester(args)
+		res, err := utils.WikiRequester(new_args)
 		if err != nil {
 			return result, err
 		}


### PR DESCRIPTION
When requesting images from this page https://de.wikipedia.org/wiki/Suliformes the code ended up in an infinite loop. Looking at the code it seems like new_args should be passed to WikiRequester instead of args. At least it solves the problem.