### PR TITLE
test: add Github actions tests, fix non-compiling code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Tests
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches:
+      - main
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: fase
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.21"
+          check-latest: true
+          cache: true
+          cache-dependency-path: go.sum
+      - uses: technote-space/get-diff-action@v6.1.2
+        id: git_diff
+        with:
+          PATTERNS: |
+            **/*.go
+            go.mod
+            go.sum
+            **/go.mod
+      - name: test
+        if: env.GIF_DIFF
+        run: |
+          go test ./...

--- a/page/page.go
+++ b/page/page.go
@@ -172,7 +172,6 @@ func (page *WikipediaPage) ContinuedQuery(args map[string]string) ([]interface{}
 		new_args := utils.CopyMap(args)
 		utils.UpdateMap(new_args, last)
 
-		res, err := utils.WikiRequester(args)
 		res, err := utils.WikiRequester(new_args)
 		if err != nil {
 			return result, err


### PR DESCRIPTION
This change adds Github actions that'll run
on every pull request, push to main. This will help
curb the case in which we have non-compiling code or
code that fails to pass tests.

Also while here fixed the non-compiling code with the intention
of a replacement that wasn't fully implemented in PR #3

Updates #5